### PR TITLE
Add cmake output directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ Programming Windows
 
 cmake-build-debug/
 cmake-build-release/
+out/build/
+out/install/
 .vs/
 .idea/
 CMakeSettings.json


### PR DESCRIPTION
On first checkout and opening in Visual Studio 2019 16.6.5 CMake runs and creates the directory ./out/build

Git then immediately has a large number of changes as it identifies this directory and contents.  I saw cmake-build-debug/ and cmake-build-release/ in the .gitignore so added this directory as well, In CMakeSettings.json I see "buildRoot": "${projectDir}\\out\\build\\${name}" and  "installRoot": "${projectDir}\\out\\install\\${name}"

I have forked your project and set my upstream to your repo so I can keep the master in sync. I plan to create a branch and work from there (pull request back to master).