### PR TITLE
Bugfix: Chap09 Colors1 SetWindowSubclass passed wrong HWND

### DIFF
--- a/Chapter 09 Child Window Controls/Colors1/Colors1.c
+++ b/Chapter 09 Child Window Controls/Colors1/Colors1.c
@@ -126,7 +126,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 				hwnd, (HMENU)(i + 2 * N),
 				hInstance, NULL);
 
-			SetWindowSubclass(hwnd, ScrollProc, (UINT_PTR)i, 0);
+			SetWindowSubclass(hwndScroll[i], ScrollProc, (UINT_PTR)i, 0);
 
 			hBrush[i] = CreateSolidBrush(crPrim[i]);
 		}


### PR DESCRIPTION
Subclassing window of the three hwndScroll[i]'s (within for loop iterating through the three scroll bars). The subclass should be passed the scrollbar window handle and not the main window handle. This is preventing tab key functionality scrolling changing focus.