### PR TITLE
Chap10 PoePoem fix to allow modification to text within a resource (WinXP onwards)

### DIFF
--- a/Chapter 10 Menus and Other Resources/PoePoem/PoePoem.c
+++ b/Chapter 10 Menus and Other Resources/PoePoem/PoePoem.c
@@ -125,7 +125,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			{
 				if (*pWorking == '\n')
 					iNumLines++;
-				pWorking = AnsiNext(pText);
+				pWorking = AnsiNext(pWorking);
 			}
 			*pWorking = '\0';
 		

--- a/Chapter 10 Menus and Other Resources/PoePoem/PoePoem.c
+++ b/Chapter 10 Menus and Other Resources/PoePoem/PoePoem.c
@@ -128,7 +128,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 				pWorking = AnsiNext(pWorking);
 			}
 			*pWorking = '\0';
-		
+		}
 
 		SetScrollRange(hScroll, SB_CTL, 0, iNumLines, FALSE);
 		SetScrollPos(hScroll, SB_CTL, 0, FALSE);


### PR DESCRIPTION
No longer possible to overwrite the '\0' character in the resource data. Instead it is necessary to copy the resource text  data to a temporary buffer and perform modifications there.  https://stackoverflow.com/questions/2933295/embed-text-file-in-a-resource-in-a-native-windows-application